### PR TITLE
[types] Removes RMQ routing key from marvin config

### DIFF
--- a/types/marvin.go
+++ b/types/marvin.go
@@ -4,7 +4,6 @@ type MarvinConfig struct {
 	MachineryTaskID   string   `toml:"taskID"`
 	RunID             string   `toml:"runID"`
 	RunType           string   `toml:"runType"`
-	RMQRoutingKey     string   `toml:"rmqRoutingKey"`
 	CheckSeq          string   `toml:"checkSeq"`
 	AnalyzerShortcode string   `toml:"analyzerShortcode"`
 	AnalyzerCommand   string   `toml:"analyzerCommand"`


### PR DESCRIPTION
Picked from ENV. Preset on the container by the executor

Signed-off-by: Jaipradeesh <jai@deepsource.io>