### PR TITLE
[PLE-1935]: feat: add `IsForDefaultAnalysisBranch` type in `AnalysisRunVCSMeta` and `MarvinAnalysisConfig`

### DIFF
--- a/types/analysis.go
+++ b/types/analysis.go
@@ -106,16 +106,17 @@ type CancelCheckResultCeleryTask struct {
 
 //proteus:generate
 type MarvinAnalysisConfig struct {
-	RunID             string           `toml:"runID"`
-	CheckSeq          string           `toml:"checkSeq"`
-	AnalyzerShortcode string           `toml:"analyzerShortcode"`
-	AnalyzerCommand   string           `toml:"analyzerCommand"`
-	AnalyzerType      string           `toml:"analyzerType"`
-	BaseOID           string           `toml:"baseOID"`
-	CheckoutOID       string           `toml:"checkoutOID"`
-	DSConfigUpdated   bool             `toml:"dsConfigUpdated"`
-	Processors        []string         `toml:"processors"`
-	DiffMetaCommits   []DiffMetaCommit `toml:"diffMetaCommits"`
+	RunID                      string           `toml:"runID"`
+	CheckSeq                   string           `toml:"checkSeq"`
+	AnalyzerShortcode          string           `toml:"analyzerShortcode"`
+	AnalyzerCommand            string           `toml:"analyzerCommand"`
+	AnalyzerType               string           `toml:"analyzerType"`
+	BaseOID                    string           `toml:"baseOID"`
+	CheckoutOID                string           `toml:"checkoutOID"`
+	IsForDefaultAnalysisBranch bool             `toml:"isForDefaultAnalysisBranch"`
+	DSConfigUpdated            bool             `toml:"dsConfigUpdated"`
+	Processors                 []string         `toml:"processors"`
+	DiffMetaCommits            []DiffMetaCommit `toml:"diffMetaCommits"`
 }
 
 //proteus:generate

--- a/types/atlas_reception.go
+++ b/types/atlas_reception.go
@@ -2,6 +2,7 @@ package types
 
 // RepoRun type is the expected structure of a repo run task
 // to be received
+//
 //proteus:generate
 type RepoRunVCSMeta struct {
 	RemoteURL   string `json:"remote_url"`
@@ -24,13 +25,15 @@ type Artifact struct {
 
 // AnalysisRun type is the expected structure of a analysis run task
 // to be received
+//
 //proteus:generate
 type AnalysisRunVCSMeta struct {
-	RemoteURL       string `json:"remote_url"`
-	BaseBranch      string `json:"base_branch"`
-	BaseOID         string `json:"base_oid"`
-	CheckoutOID     string `json:"checkout_oid"`
-	CloneSubmodules bool   `json:"clone_submodules"`
+	RemoteURL                  string `json:"remote_url"`
+	BaseBranch                 string `json:"base_branch"`
+	BaseOID                    string `json:"base_oid"`
+	CheckoutOID                string `json:"checkout_oid"`
+	IsForDefaultAnalysisBranch bool   `json:"is_for_default_analysis_branch"`
+	CloneSubmodules            bool   `json:"clone_submodules"`
 }
 
 //proteus:generate
@@ -171,6 +174,7 @@ type SSHVerifyResultCeleryTask struct {
 
 // CancelCheckRun type is the expected structure of a check cancellation
 // task to be recieved
+//
 //proteus:generate
 type CancelCheckAnalysisMeta struct {
 	RunID     string `json:"run_id"`
@@ -187,6 +191,7 @@ type CancelCheckRun struct {
 
 // Beacon type is the expected structure of a beacon task
 // to be received
+//
 //proteus:generate
 type BeaconRun struct {
 	RunID        string `json:"run_id"`

--- a/types/autofix.go
+++ b/types/autofix.go
@@ -47,6 +47,7 @@ type AutofixResultCeleryTask struct {
 }
 
 // Issues to be autofixed
+//
 //proteus:generate
 type AutofixIssue struct {
 	IssueCode   string          `json:"issue_code"`


### PR DESCRIPTION
Add `IsForDefaultAnalysisBranch` in `AnalysisRunVCSMeta` and `MarvinAnalysisConfig` so that atlas can consume the same. Extra comments `//` are added by `gofmt`.