### PR TITLE
feat: add `sparseCheckoutPath` to VCSMeta(s)

### DIFF
--- a/types/atlas_reception.go
+++ b/types/atlas_reception.go
@@ -1,9 +1,5 @@
 package types
 
-
-
-
-
 // RepoRun type is the expected structure of a repo run task
 // to be received
 //


### PR DESCRIPTION
## Description

Partially resolves: PDE-2227.

Adds `SparseCheckoutPath` field to all the VCSMeta structs.
