### PR TITLE
api: pass broker URL to dialer

### DIFF
--- a/amqp_utils.go
+++ b/amqp_utils.go
@@ -12,9 +12,9 @@ var ConsumerChannelActive = true
 
 // SetupRMQConnection sets up the RabbitMQ connection and channels. It also spawns a goroutine that listens for any
 // "Close" events from the broker.
-func SetupRMQConnection(retryFunc func() error, exchangeName, exchangeType string) (*amqp.Connection, *amqp.Channel, error) {
+func SetupRMQConnection(retryFunc func() error, brokerUrl, exchangeName, exchangeType string) (*amqp.Connection, *amqp.Channel, error) {
 	// Establish connection with RabbitMQ
-	rmqConn, err := dialRMQ()
+	rmqConn, err := dialRMQ(brokerUrl)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/dial_utils.go
+++ b/dial_utils.go
@@ -2,7 +2,6 @@ package artifacts
 
 import (
 	"log"
-	"os"
 	"time"
 
 	"github.com/streadway/amqp"
@@ -12,13 +11,13 @@ var maxRetryCount = 12
 
 // dialRMQ creates a connection with RabbiMQ and stores the amqp connection
 // object for usage by other functions
-func dialRMQ() (rmqConn *amqp.Connection, err error) {
+func dialRMQ(brokerUrl string) (rmqConn *amqp.Connection, err error) {
 	retryTimeout := 1
 	retryCount := 0
 	var retryDuration time.Duration
 
 	for {
-		if rmqConn, err = amqp.Dial(os.Getenv("BROKER_URL")); err == nil {
+		if rmqConn, err = amqp.Dial(brokerUrl); err == nil {
 			log.Println("Successfully reconnected to RabbitMQ")
 			return rmqConn, nil
 		}


### PR DESCRIPTION
Currently, the broker URL for RMQ is picked up from the environment as `BROKER_URL`. This is not ideal, as the dialer can be used in multiple applications, not all of which may use this env variable. This change fixes that. This breaks the contract in two known applications, both of which have corresponding changes.