### PR TITLE
chore: add extra data field to fix path and SCAPatch

### DIFF
--- a/types/sca.go
+++ b/types/sca.go
@@ -343,8 +343,9 @@ type SCAPatchTarget struct {
 }
 
 type SCAPatch struct {
-	Vulnerability Vulnerability      `json:"vulnerability"`
-	Updates       []SCAPackageUpdate `json:"updates"`
+	Vulnerability Vulnerability          `json:"vulnerability"`
+	Updates       []SCAPackageUpdate     `json:"updates"`
+	ExtraData     map[string]interface{} `json:"extra_data"`
 }
 
 type SCAPatchResult struct {

--- a/types/sca.go
+++ b/types/sca.go
@@ -248,9 +248,9 @@ type VulnerabilityRemediation struct {
 }
 
 type FixPath struct {
-	Updates       []SCAPackageUpdate `json:"updates"`
-	ExtraData     map[string]interface{}        `json:"extra_data"`
-	IsRecommended bool               `json:"is_recommended"`
+	Updates       []SCAPackageUpdate     `json:"updates"`
+	ExtraData     map[string]interface{} `json:"extra_data"`
+	IsRecommended bool                   `json:"is_recommended"`
 }
 
 type SCAPackageUpdate struct {

--- a/types/sca.go
+++ b/types/sca.go
@@ -249,6 +249,7 @@ type VulnerabilityRemediation struct {
 
 type FixPath struct {
 	Updates       []SCAPackageUpdate `json:"updates"`
+	ExtraData     map[string]interface{}        `json:"extra_data"`
 	IsRecommended bool               `json:"is_recommended"`
 }
 


### PR DESCRIPTION
We can use this to pass on information to analyzers that we gather during fix path creation.

This would avoid the need to create a venv and install add deps all over again, and resolve dependencies again at the time of patch run. 
Would result in faster patch creation. 