### PR TITLE
chore: send spdx sbom for target

### DIFF
--- a/types/sca.go
+++ b/types/sca.go
@@ -99,6 +99,7 @@ type SCATargetResult struct {
 	Dependencies    []Dependency    `json:"dependencies"`
 	ExtraData       interface{}     `json:"extra_data"`
 	Errors          []AnalysisError `json:"errors"`
+	SpdxSbom        string          `json:"spdx_sbom"`
 }
 
 type Dependency struct {


### PR DESCRIPTION
Analyzer would be sending a base64 encoded string of zstd compressed spdx sbom report in the result.