### PR TITLE
feat(ENG-4341): add InternalToken field to AnalysisRun

### DIFF
--- a/types/atlas_reception.go
+++ b/types/atlas_reception.go
@@ -105,6 +105,7 @@ type AnalysisRun struct {
 	Meta                          map[string]string  `json:"_meta"`
 	PreviousCompletedRunCommitOID string             `json:"previous_completed_run_commit_oid"` // Previous completed run commit OID for deduplication.
 	RepoID                        int64              `json:"repo_id"`
+	InternalToken                 string             `json:"internal_token"`
 }
 
 //proteus:generate


### PR DESCRIPTION
## Summary
- Add `InternalToken` field to `AnalysisRun` struct for passing owner-scoped JWTs to analyzers

## Related PRs
- DeepSourceCorp/asgard#6740
- DeepSourceCorp/atlas — eng-4341 branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)