### PR TITLE
feat(ENG-4375): add PreviousCompletedAIRunCommitOID to AnalysisRunVCSMeta

### DIFF
--- a/types/atlas_reception.go
+++ b/types/atlas_reception.go
@@ -28,14 +28,14 @@ type Artifact struct {
 //
 //proteus:generate
 type AnalysisRunVCSMeta struct {
-	RemoteURL                     string `json:"remote_url"`
-	BaseBranch                    string `json:"base_branch"`
-	BaseOID                       string `json:"base_oid"`
-	CheckoutOID                   string `json:"checkout_oid"`
-	RepositoryName                string `json:"repository_name"`
-	IsForDefaultAnalysisBranch    bool   `json:"is_for_default_analysis_branch"`
-	CloneSubmodules               bool   `json:"clone_submodules"`
-	SparseCheckoutPath            string `json:"sparse_checkout_path"`
+	RemoteURL                       string `json:"remote_url"`
+	BaseBranch                      string `json:"base_branch"`
+	BaseOID                         string `json:"base_oid"`
+	CheckoutOID                     string `json:"checkout_oid"`
+	RepositoryName                  string `json:"repository_name"`
+	IsForDefaultAnalysisBranch      bool   `json:"is_for_default_analysis_branch"`
+	CloneSubmodules                 bool   `json:"clone_submodules"`
+	SparseCheckoutPath              string `json:"sparse_checkout_path"`
 	PreviousCompletedRunCommitOID   string `json:"previous_completed_run_commit_oid"`    // Previous completed run commit OID.
 	PreviousCompletedAIRunCommitOID string `json:"previous_completed_ai_run_commit_oid"` // Previous completed AI review run commit OID.
 	BranchName                      string `json:"branch_name,omitempty"`                // Source/PR branch name.

--- a/types/atlas_reception.go
+++ b/types/atlas_reception.go
@@ -36,8 +36,9 @@ type AnalysisRunVCSMeta struct {
 	IsForDefaultAnalysisBranch    bool   `json:"is_for_default_analysis_branch"`
 	CloneSubmodules               bool   `json:"clone_submodules"`
 	SparseCheckoutPath            string `json:"sparse_checkout_path"`
-	PreviousCompletedRunCommitOID string `json:"previous_completed_run_commit_oid"` // Previous completed run commit OID.
-	BranchName                    string `json:"branch_name,omitempty"`             // Source/PR branch name.
+	PreviousCompletedRunCommitOID   string `json:"previous_completed_run_commit_oid"`    // Previous completed run commit OID.
+	PreviousCompletedAIRunCommitOID string `json:"previous_completed_ai_run_commit_oid"` // Previous completed AI review run commit OID.
+	BranchName                      string `json:"branch_name,omitempty"`                // Source/PR branch name.
 }
 
 //proteus:generate


### PR DESCRIPTION
## Summary
- Adds `PreviousCompletedAIRunCommitOID` field to `AnalysisRunVCSMeta` struct
- Asgard (PR #6708) now sends `previous_completed_ai_run_commit_oid` in analysis run messages for AI-specific incremental diffs
- Without this field, the value is silently dropped during deserialization

## Test plan
- [ ] Verify Atlas deserializes the new field from analysis run messages
- [ ] Verify existing messages without the field still deserialize correctly (zero value default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)