### PR TITLE
feat(ENG-4348): add InternalToken to ConfigGenerationRun

### DIFF
--- a/types/atlas_reception.go
+++ b/types/atlas_reception.go
@@ -292,8 +292,9 @@ type BeaconRun struct {
 }
 
 type ConfigGenerationRun struct {
-	RunID   string                  `json:"run_id"`
-	VCSMeta ConfigGenerationVCSMeta `json:"vcs_meta"`
+	RunID         string                  `json:"run_id"`
+	InternalToken string                  `json:"internal_token"`
+	VCSMeta       ConfigGenerationVCSMeta `json:"vcs_meta"`
 }
 
 type ConfigGenerationVCSMeta struct {


### PR DESCRIPTION
## Summary
- Add `InternalToken` field to `ConfigGenerationRun` struct so asgard can pass a muninn JWT for configgen tasks

## Related PRs
- Asgard: DeepSourceCorp/asgard#6770 (mints the token)
- Atlas: DeepSourceCorp/atlas#726 (injects it as MUNINN_TOKEN env var)

🤖 Generated with [Claude Code](https://claude.com/claude-code)