### PR TITLE
feat(ENG-4585): add IsAIOnlyAnalyzer field to AnalyzerMeta

### DIFF
--- a/types/atlas_reception.go
+++ b/types/atlas_reception.go
@@ -66,16 +66,17 @@ type Keys struct {
 
 //proteus:generate
 type AnalyzerMeta struct {
-	Shortcode    string `json:"name"`
-	ImagePath    string `json:"image_path"`
-	AnalyzerType string `json:"analyzer_type"`
-	Command      string `json:"command"`
-	Version      string `json:"version"`
-	CPULimit     string `json:"cpu_limit"`
-	MemoryLimit  string `json:"memory_limit"`
-	CacheVersion int    `json:"cache_version"`
-	Trigger      string `json:"trigger,omitempty"`
-	IsAIEnabled  bool   `json:"is_ai_enabled"`
+	Shortcode        string `json:"name"`
+	ImagePath        string `json:"image_path"`
+	AnalyzerType     string `json:"analyzer_type"`
+	Command          string `json:"command"`
+	Version          string `json:"version"`
+	CPULimit         string `json:"cpu_limit"`
+	MemoryLimit      string `json:"memory_limit"`
+	CacheVersion     int    `json:"cache_version"`
+	Trigger          string `json:"trigger,omitempty"`
+	IsAIEnabled      bool   `json:"is_ai_enabled"`
+	IsAIOnlyAnalyzer bool   `json:"is_ai_only_analyzer"`
 }
 
 //proteus:generate


### PR DESCRIPTION
## Summary
Adds `is_ai_only_analyzer` to the Atlas `analyzer_meta` payload so Atlas can distinguish AI-only analyzers (e.g. Dart) from regular analyzers. When `true`, Atlas skips the static analyzer pod and only runs AI review — see the dispatcher side in DeepSourceCorp/asgard#6793.

## Companion PRs
- DeepSourceCorp/asgard#6793 (Asgard — adds the flag and emits it in atlas message)
- Atlas (follow-up PR — consumes the flag)
- Marvin (follow-up PR — adds --ai-only-run)
- Enki (follow-up PR — adds Dart to supported extensions)

Linear: https://linear.app/deepsource/issue/ENG-4585

## Test plan
- [x] Field marshals with the correct JSON tag (`is_ai_only_analyzer`) to match the asgard side

🤖 Generated with [Claude Code](https://claude.com/claude-code)